### PR TITLE
Jboss6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,9 +8,9 @@
   </parent>
 
   <scm>
-    <connection>scm:svn:https://www.silverpeas.org/svn/silverpeas/assembly-silverpeas/trunk</connection>
-    <developerConnection>scm:svn:https://www.silverpeas.org/svn/silverpeas/assembly-silverpeas/trunk</developerConnection>
-    <url>https://www.silverpeas.org/svn/silverpeas/assembly-silverpeas/trunk</url>
+    <connection>scm:git:git@github.com:Silverpeas/Assembly-Silverpeas.git</connection>
+    <developerConnection>scm:git:git@github.com:Silverpeas/Assembly-Silverpeas.git</developerConnection>
+    <url>http://gitub.com/Silverpeas/Assembly-Silverpeas.git</url>
   </scm>
 
   <repositories>


### PR DESCRIPTION
End of the portage of Silverpeas in JBoss 6.0.
Takes into account of the new version of the assembly-structure module that refines the layout of the silverpeas installation home directory.
