### PR TITLE
For feature #12866

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
   <parent>
     <groupId>org.silverpeas</groupId>
     <artifactId>silverpeas-project</artifactId>
-    <version>1.5</version>
+    <version>1.6-SNAPSHOT</version>
   </parent>
 
   <packaging>pom</packaging>
@@ -81,7 +81,7 @@
     <next.release>6.4</next.release>
     <core.version>${project.version}</core.version>
     <components.version>${project.version}</components.version>
-    <jackrabbit.version>2.20.5</jackrabbit.version>
+    <jcr.version>1.0-SNAPSHOT</jcr.version>
   </properties>
 
   <dependencies>
@@ -731,12 +731,11 @@
       <version>${core.version}</version>
     </dependency>
 
-    <!-- Jackrabbit JCA -->
+    <!-- JCR -->
     <dependency>
       <groupId>org.silverpeas.jcr</groupId>
-      <artifactId>jackrabbit-jca</artifactId>
-      <version>${jackrabbit.version}</version>
-      <type>rar</type>
+      <artifactId>silverpeas-jcr</artifactId>
+      <version>${jcr.version}</version>
     </dependency>
 
     <!-- JDBC drivers -->

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,6 @@
     <next.release>6.4</next.release>
     <core.version>${project.version}</core.version>
     <components.version>${project.version}</components.version>
-    <jcr.version>1.0-SNAPSHOT</jcr.version>
   </properties>
 
   <dependencies>
@@ -729,13 +728,6 @@
       <groupId>org.silverpeas.core.services</groupId>
       <artifactId>silverpeas-core-sharing</artifactId>
       <version>${core.version}</version>
-    </dependency>
-
-    <!-- JCR -->
-    <dependency>
-      <groupId>org.silverpeas.jcr</groupId>
-      <artifactId>silverpeas-jcr</artifactId>
-      <version>${jcr.version}</version>
     </dependency>
 
     <!-- JDBC drivers -->


### PR DESCRIPTION
Take into account the JCR implementation is now brought by a lib and not anymore by a JCA.

The following PRs require to be integrated before this one:
- https://github.com/Silverpeas/silverpeas-dependencies-bom/pull/47
- https://github.com/Silverpeas/Silverpeas-Core/pull/1255
- https://github.com/Silverpeas/Silverpeas-Components/pull/809

The following PRs require to be integrated after this one:
- https://github.com/Silverpeas/Silverpeas-Setup/pull/28
- https://github.com/Silverpeas/Silverpeas-Distribution/pull/10